### PR TITLE
fix copy cleaned link from RMB

### DIFF
--- a/background.js
+++ b/background.js
@@ -25,7 +25,8 @@ function clean_amp(url) {
     return new_url;
 }
 
-// Clean URL query params only
+// Clean URL query params only (one or all of them)
+// see cleaning_rules.js
 function link_cleaner(orig_url, shouldRemove) {
     // console.debug("[link_cleaner] got " + orig_url + " and " + shouldRemove);
     var url = new URL(orig_url);

--- a/cleaning_rules.js
+++ b/cleaning_rules.js
@@ -93,7 +93,7 @@ var instagram_regexp = [
     "*://*.instagram.com/*",
 ];
 
-// query params matching
+// query params matching used in link_cleaner()
 
 var f_match_utm = p => p.startsWith("utm_");
 var f_match_all = p => true;

--- a/copy.js
+++ b/copy.js
@@ -41,15 +41,16 @@ function maybe_clean_url (orig_url, urls, f) {
     return (res != '' ? res : orig_url);
 }
 
+// this is only invoked on right-click menu action
 function cleaner_entrypoint (orig_link) {
 
-    // query params matching
+    // Remove tracking params form url
     // TODO: profile && improve perfs here
-
-    var new_link = maybe_clean(orig_link, all_urls, f_match_utm);
-    new_link = maybe_clean(new_link, aliexpress_regexp, f_match_all);
+    let new_link = maybe_clean(orig_link, all_urls, f_match_utm);
     new_link = maybe_clean(new_link, all_urls, f_match_fbclid);
+    new_link = maybe_clean(new_link, aliexpress_regexp, f_match_all);
     new_link = maybe_clean(new_link, fbcontent_regexp, f_match_fbcontent);
+    new_link = maybe_clean(new_link, instagram_regexp, f_match_igshid);
 
     // clean URL
     new_link = maybe_clean_url(new_link, ["amazon"], clean_amazon);
@@ -58,7 +59,7 @@ function cleaner_entrypoint (orig_link) {
     return new_link;
 }
 
-function copyToClipboard(text) {
+function copyToClipboard(obj) {
     // does not work inside frame
     if ((document.activeElement instanceof HTMLIFrameElement) ||
         (document.activeElement instanceof HTMLFrameElement)) {
@@ -67,9 +68,13 @@ function copyToClipboard(text) {
         document.activeElement.blur();
     }
 
-    // sequential execution of all cleaners
-    console.debug("[copytoclipboard] link to be cleaned " + text);
-    global_link_text = cleaner_entrypoint(text);
+    // if there is a link, clean it, otherwise copy the text
+    if (obj.linkUrl !== undefined) {
+        // sequential execution of all cleaners
+        global_link_text = cleaner_entrypoint(obj.linkUrl);
+    } else {
+        global_link_text = obj.selectionText;
+    }
 
     // trigger cleaned link copy back in clipboard
     document.execCommand("copy");

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,8 @@
         "webRequestBlocking",
         "contextMenus",
         "menus",
-        "storage"
+        "storage",
+        "clipboardWrite"
     ],
     "options_ui": {
         "page": "options/options.html"

--- a/menu.js
+++ b/menu.js
@@ -34,7 +34,7 @@ browser.menus.create({
 browser.menus.onClicked.addListener((info, tab) => {
     switch (info.menuItemId) {
     case "copy-link":
-        copyToClipboard(info.linkUrl);
+        copyToClipboard(info);
         break;
     }
 });


### PR DESCRIPTION
Fixes #11 

- Added missing permission (see [docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard))
- fixed when copied text does not contain a link
- added one missing link clean on action right-mouse menu