### PR TITLE
[discussion] Reduce listeners, increase number of query params checked on every url

### DIFF
--- a/background.js
+++ b/background.js
@@ -85,7 +85,7 @@ browser.webRequest.onBeforeRequest.addListener(
 );
 
 // Filter out Facebook Click Identifier query parameters
-var clean_fbclid = build_query_param_remover(f_match_fbclid);
+var clean_fbclid = build_query_param_remover(f_match_fb);
 browser.webRequest.onBeforeRequest.addListener(
     clean_fbclid,
     {
@@ -163,25 +163,15 @@ browser.webRequest.onBeforeRequest.addListener(
     ["blocking"]
 );
 
-var remove_fbcontentparam = build_query_param_remover(f_match_fbcontent);
-browser.webRequest.onBeforeRequest.addListener(
-    remove_fbcontentparam,
-    {
-        urls: fbcontent_regexp,
-        types: ["main_frame"]
-    },
-    ["blocking"]
-);
-
 function redirect_to_query_param (query_param, url) {
-    console.log("[redirect_to_query_param] will pick p=" + query_param + " url=" + url);
+    // console.log("[redirect_to_query_param] will pick p=" + query_param + " url=" + url);
     const search_params = new URLSearchParams(new URL(url).search);
     const real_url_from_param = search_params.get(query_param);
     if (real_url_from_param) {
-        console.log('[redirect_to_query_param] Redirecting to ' + real_url_from_param);
+        // console.log('[redirect_to_query_param] Redirecting to ' + real_url_from_param);
         return { redirectUrl: real_url_from_param };
     }
-    console.log('[redirect_to_query_param] no redirect');
+    // console.log('[redirect_to_query_param] no redirect');
     return { redirectUrl: '' };
 };
 

--- a/cleaning_rules.js
+++ b/cleaning_rules.js
@@ -95,8 +95,12 @@ const instagram_regexp = [
 
 // query params matching used in link_cleaner()
 
+// various facebook trackers
+const fb_tracking = [
+    'if_id', '__tn__', 'efg', 'eid', 'fref', '__xts__', 'fbadid', 'fbclid'
+];
+
 const f_match_utm = p => p.startsWith("utm_");
 const f_match_all = p => true;
-const f_match_fbclid = p => p == "fbclid";
 const f_match_igshid = p => p == "igshid";
-const f_match_fbcontent = p => p == "efg";
+const f_match_fb = p => fb_tracking.includes(p);

--- a/copy.js
+++ b/copy.js
@@ -69,9 +69,9 @@ function cleaner_entrypoint (orig_link) {
     // 2nd check: remove tracking query params
     // TODO: profile && improve perfs here
     new_link = maybe_clean(new_link, all_urls, f_match_utm);
-    new_link = maybe_clean(new_link, all_urls, f_match_fbclid);
+    new_link = maybe_clean(new_link, all_urls, f_match_fb);
     new_link = maybe_clean(new_link, aliexpress_regexp, f_match_all);
-    new_link = maybe_clean(new_link, fbcontent_regexp, f_match_fbcontent);
+    // new_link = maybe_clean(new_link, fbcontent_regexp, f_match_fbcontent);
     new_link = maybe_clean(new_link, instagram_regexp, f_match_igshid);
 
     // 3rd check: (optional) clean Amazon URL


### PR DESCRIPTION
### This is a open discussion on how we can plan for a better scalability and perfomance of the extension.

Looking at the code, I think the way we manage query parameters removal does not scale well. Brief recap:

- We have a number of listeners attached to [onBeforeRequest](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest): each listeners filters some query params to a specific URL regexp. Example for `"*://*.instagram.com/*"` filter out the query param `igshid`.

- We have some more listeners that apply to any URL the browser is processing. Example: remove the query params `utm_*` from any URL.

Instead of adding a new listener everytime a user asks us to support a new website and remove one or two parameters, I was wondering if it would make more sense to reduce the number of listeners and increase the number of query params checked on any URL. Example: blindly check and remove all these query params `if_id, utm_*, efg, eid, fref,...` on every URL the browser is processing.

The reason I'm asking this is manyfold:
1) Would reducing the number of listeners decrease the footprint of the addon on the browser? I don't know the internals of a browser but I guess that the [url filters we give to the listeners](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter) is nothing but a fast regexp itself.
2) Expected advantage: if we reduce the listeners theoretically to one ("all urls") we can then extend more easily the number of query params checked, simply adding an item to a list.
3) How can we profile the extension performances? How can I measure if it's more lightweight adding a long chain of query params check to one listener, rather than attaching many listeners, each checking just a couple of query params?

and ...

4) I'm thinking that if we centralize and reduce the points where the regexp checks happen, we can prepare for a future rewrite of the "core" with something more performant (form example using a statically compiled language)

5) reducing the amount of code logic would enable us to more easily port the extension to other browsers (something that I still didn't investigate) that support the WebExt API