### PR TITLE
Add wildcards to URLs to filter

### DIFF
--- a/background.js
+++ b/background.js
@@ -219,13 +219,13 @@ const urls_to_param_mappers = [
         query_param: 'q'
     },
     {
-        urls: ["*://slack-redir.net/link"]
+        urls: ["*://slack-redir.net/link*"]
     },
     {
-        urls: ["*://x.chip.de/"]
+        urls: ["*://x.chip.de/linktrack/button/*"]
     },
     {
-        urls: ["*://*getpocket.com/*"]
+        urls: ["*://getpocket.com/redirect*", "*://www.getpocket.com/redirect*"]
     }
 ];
 


### PR DESCRIPTION
Firefox was previously not listening to these URLs because there was no
wildcard added to account for URL params, which were what we were trying
to filter in the first place. Oops.

Fixes #25 