### PR TITLE
Fix cleaning copied Twitter URLs

### DIFF
--- a/cleaning_rules.js
+++ b/cleaning_rules.js
@@ -101,7 +101,8 @@ const instagram_regexp = [
 ];
 
 const twitter_regexp = [
-    "*://*.twitter.com/*"
+    "*://*.twitter.com/*",
+    "*://twitter.com/*",
 ]
 
 // query params matching used in link_cleaner()

--- a/copy.js
+++ b/copy.js
@@ -73,6 +73,7 @@ function cleaner_entrypoint (orig_link) {
     new_link = maybe_clean(new_link, aliexpress_regexp, f_match_all);
     new_link = maybe_clean(new_link, fbcontent_regexp, f_match_fbcontent);
     new_link = maybe_clean(new_link, instagram_regexp, f_match_igshid);
+    new_link = maybe_clean(new_link, twitter_regexp, t_match_s_or_t);
 
     // 3rd check: (optional) clean Amazon URL
     if (settings['clean_amp_links'] === true) {

--- a/test_urls.html
+++ b/test_urls.html
@@ -160,5 +160,8 @@
   <a href="https://twitter.com/jack/status/20?s=20&t=_x-3XahP6TiTu_0lDkcEig">twitter shared tweet</a>
 
   <br /><br />
+  <a href="https://www.twitter.com/jack/status/20?s=20&t=_x-3XahP6TiTu_0lDkcEig">twitter shared tweet (www)</a>
+
+  <br /><br />
   paste cleaned link here:<br />
   <textarea cols=80 rows=10></textarea>

--- a/test_urls.md
+++ b/test_urls.md
@@ -33,3 +33,5 @@ https://medium.com/m/global-identity?redirectUrl=https://blog.unocoin.com/how-tr
 https://jsv3.recruitics.com/redirect?rx_cid=3308&rx_jobId=R181269&rx_url=https%3A//careers.arrow.com/us/en/job/R181269/Accounting-Consolidations-Reporting-Analyst-II%3Futm_medium%3Dphenom-feeds%26utm_source%3Dbuiltincolorado%26rx_medium%3Dpost%26rx_paid%3D1%26rx_r%3Dnone%26rx_source%3Dbuiltinco%26rx_ts%3D20201116T192433Z
 
 https://twitter.com/jack/status/20?s=20&t=_x-3XahP6TiTu_0lDkcEig
+
+https://www.twitter.com/jack/status/20?s=20&t=_x-3XahP6TiTu_0lDkcEig


### PR DESCRIPTION
As [pointed out](https://github.com/apiraino/link_cleaner/pull/40#issuecomment-1208748496) by @ZacharyTalis, my initial implementation of Twitter cleaning missed the "Copy Clean URL" functionality. This properly implements copying cleaned Twitter URLs.

Again, I've left the CHANGELOG and Manifest alone.