### PR TITLE
feat: handle search.app links

### DIFF
--- a/background.js
+++ b/background.js
@@ -230,6 +230,10 @@ const urls_to_param_mappers = [
         query_param: 'q'
     },
     {
+        urls: ["*://search.app/*"],
+        query_param: 'link'
+    },
+    {
         urls: ["*://slack-redir.net/link*"]
     },
     {

--- a/test_urls.html
+++ b/test_urls.html
@@ -160,5 +160,8 @@
   <a href="https://twitter.com/jack/status/20?s=20&t=_x-3XahP6TiTu_0lDkcEig">twitter shared tweet</a>
 
   <br /><br />
+  <a href="https://search.app/?link=https%3A%2F%2Fgithub.com%2Fapiraino%2Flink_cleaner%2F">search.app (Google) redirect</a>
+
+  <br /><br />
   paste cleaned link here:<br />
   <textarea cols=80 rows=10></textarea>

--- a/test_urls.md
+++ b/test_urls.md
@@ -33,3 +33,5 @@ https://medium.com/m/global-identity?redirectUrl=https://blog.unocoin.com/how-tr
 https://jsv3.recruitics.com/redirect?rx_cid=3308&rx_jobId=R181269&rx_url=https%3A//careers.arrow.com/us/en/job/R181269/Accounting-Consolidations-Reporting-Analyst-II%3Futm_medium%3Dphenom-feeds%26utm_source%3Dbuiltincolorado%26rx_medium%3Dpost%26rx_paid%3D1%26rx_r%3Dnone%26rx_source%3Dbuiltinco%26rx_ts%3D20201116T192433Z
 
 https://twitter.com/jack/status/20?s=20&t=_x-3XahP6TiTu_0lDkcEig
+
+https://search.app/?link=https%3A%2F%2Fgithub.com%2Fapiraino%2Flink_cleaner%2F


### PR DESCRIPTION
Since early November, Google's Android app opens search results in an in-app browser that modifies the URLs so that they go through their `search.app` domain once shared[^1].

This PR adds support for that redirect.

[^1]: https://www.bleepingcomputer.com/news/security/googles-mysterious-searchapp-links-leave-android-users-concerned/